### PR TITLE
specifies Python Version to use on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Download and create a virtual environment:
     mkvirtualenv -p python3 googlephotos (_or any other name_)
     pip install -r requirements.txt
     python ./gp.py -?
-
+    
+*Note: On on Windows use Python 3.8 version max to avoid legacy-install-failure error while trying to install package `cffi`*
 
 ## Configuration
 To avoid having to re-authenticate with Google all the time, the application expects credentials to be


### PR DESCRIPTION
I encountered an error on Python 3.9 and 3.10 on windows while `pip install -r requirements.txt`:

```
error `legacy-install-failure`

Encountered error while trying to install package.
╰─> cffi
```

 After trying several things downgrading to python 3.8 fixed the issue (see https://stackoverflow.com/a/69557701).
 
 This addition to the README could help others avoid loosing time like I did.