### PR TITLE
call create_database_structure() on check - fix #9

### DIFF
--- a/gp.py
+++ b/gp.py
@@ -398,6 +398,7 @@ def main():
         list_albums(authed_session)
 
     if args.check:
+        create_database_structure()
         check_files(args.imagedir)
 
     if args.upload:


### PR DESCRIPTION
If running command check (`-c`) before running upload command (`-u`) the program crashes because the database is not created yet. This adds create_database_structure() when checking.